### PR TITLE
Fixes trim method fixes #3

### DIFF
--- a/spec/cadmium/tokenizer/aggressive_tokenizer_spec.cr
+++ b/spec/cadmium/tokenizer/aggressive_tokenizer_spec.cr
@@ -29,7 +29,7 @@ describe Cadmium::AggressiveTokenizer do
     end
 
     it "should return an empty Array(String) when fed with empty string" do
-      subject.tokenize("").should eq(Array(String).new)
+      subject.tokenize("").should eq([] of String)
     end
   end
 

--- a/spec/cadmium/tokenizer/aggressive_tokenizer_spec.cr
+++ b/spec/cadmium/tokenizer/aggressive_tokenizer_spec.cr
@@ -27,6 +27,10 @@ describe Cadmium::AggressiveTokenizer do
     it "should swollow duplicate punctuation" do
       subject.tokenize("i shal... pause").should eq(["i", "shal", "pause"])
     end
+
+    it "should return emty string when fed with empty string" do
+      subject.tokenize("").should eq([""])
+    end
   end
 
   describe ":es" do

--- a/spec/cadmium/tokenizer/aggressive_tokenizer_spec.cr
+++ b/spec/cadmium/tokenizer/aggressive_tokenizer_spec.cr
@@ -28,7 +28,7 @@ describe Cadmium::AggressiveTokenizer do
       subject.tokenize("i shal... pause").should eq(["i", "shal", "pause"])
     end
 
-    it "should return emty string when fed with empty string" do
+    it "should return empty string when fed with empty string" do
       subject.tokenize("").should eq([""])
     end
   end

--- a/spec/cadmium/tokenizer/aggressive_tokenizer_spec.cr
+++ b/spec/cadmium/tokenizer/aggressive_tokenizer_spec.cr
@@ -28,8 +28,8 @@ describe Cadmium::AggressiveTokenizer do
       subject.tokenize("i shal... pause").should eq(["i", "shal", "pause"])
     end
 
-    it "should return emty string when fed with empty string" do
-      subject.tokenize("").should eq([""])
+    it "should return an empty Array(String) when fed with empty string" do
+      subject.tokenize("").should eq(Array(String).new)
     end
   end
 

--- a/src/cadmium/tokenizer/tokenizer.cr
+++ b/src/cadmium/tokenizer/tokenizer.cr
@@ -3,11 +3,11 @@ module Cadmium
     abstract def tokenize(string : String) : Array(String)
 
     def trim(arr)
-      return arr if arr.size == 1
+      return arr unless arr[0]?
       if arr[0] == ""
         arr.shift
       end
-
+      return arr unless arr[-1]?
       if arr[-1] == ""
         arr.pop
       end

--- a/src/cadmium/tokenizer/tokenizer.cr
+++ b/src/cadmium/tokenizer/tokenizer.cr
@@ -3,6 +3,7 @@ module Cadmium
     abstract def tokenize(string : String) : Array(String)
 
     def trim(arr)
+      return arr if arr.size == 1
       if arr[0] == ""
         arr.shift
       end


### PR DESCRIPTION
Fixes the `trim` method shared by all tokenizers to deal with emty strings ("")